### PR TITLE
Implement modular debate engine

### DIFF
--- a/pysrcai/pysrcai/debate/__init__.py
+++ b/pysrcai/pysrcai/debate/__init__.py
@@ -1,0 +1,5 @@
+"""Debate module providing a generic debate engine and prefabs."""
+
+from pysrcai.pysrcai.debate.engine.generic_debate import DebateEngine
+
+__all__ = ["DebateEngine"]

--- a/pysrcai/pysrcai/debate/engine/generic_debate.py
+++ b/pysrcai/pysrcai/debate/engine/generic_debate.py
@@ -1,1 +1,86 @@
-# The generic simulation framework for structured debates between entities.
+"""Generic debate simulation engine."""
+
+from pathlib import Path
+import logging
+import sys
+
+import numpy as np
+from concordia.language_model import openrouter_model
+from concordia.prefabs.game_master import dialogic_and_dramaturgic as dd_gm
+from concordia.prefabs.simulation import generic as simulation_prefab
+from concordia.testing import mock_model
+from sentence_transformers import SentenceTransformer
+
+from pysrcai.pysrcai.debate.prefabs.entity.participant import Participant
+from pysrcai.pysrcai.debate.prefabs.entity.moderator import Moderator
+
+
+class DebateEngine:
+    """Run a debate simulation from a scenario module."""
+
+    def __init__(self, scenario_module):
+        self.scenario = scenario_module
+
+    def run(self) -> str:
+        logger = logging.getLogger("debate")
+        logger.setLevel(logging.INFO)
+        if not logger.handlers:
+            handler = logging.StreamHandler(sys.stdout)
+            formatter = logging.Formatter(
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+            logger.propagate = False
+
+        try:
+            model = openrouter_model.OpenRouterLanguageModel(
+                model_name="mistralai/mistral-small-3.1-24b-instruct:free",
+                api_key=None,
+            )
+        except Exception as e:  # pragma: no cover - network not available
+            logger.warning("Falling back to mock model: %s", e)
+            model = mock_model.MockModel()
+
+        try:
+            embedder = SentenceTransformer("all-MiniLM-L6-v2")
+
+            def embed_fn(text: str) -> np.ndarray:
+                return embedder.encode(text)
+
+        except Exception as e:  # pragma: no cover - model missing
+            logger.warning("Using random embeddings: %s", e)
+
+            def embed_fn(text: str) -> np.ndarray:  # noqa: D401
+                return np.random.randn(384)
+
+        prefabs = {
+            "participant": Participant(),
+            "moderator": Moderator(),
+            "dialogic_and_dramaturgic_gm": dd_gm.GameMaster(),
+        }
+
+        config = simulation_prefab.Config(
+            prefabs=prefabs,
+            instances=self.scenario.INSTANCES,
+            default_premise=self.scenario.PREMISE,
+            default_max_steps=20,
+        )
+
+        sim = simulation_prefab.Simulation(
+            config=config,
+            model=model,
+            embedder=embed_fn,
+        )
+
+        logger.info("Starting debate simulation.")
+        results = sim.play()
+        logger.info("Debate finished.")
+
+        output_file = Path("debate_results.html")
+        with output_file.open("w", encoding="utf-8") as f:
+            f.write(results)
+        logger.info("Results saved to %s", output_file)
+
+        return results

--- a/pysrcai/pysrcai/debate/prefabs/entity/moderator.py
+++ b/pysrcai/pysrcai/debate/prefabs/entity/moderator.py
@@ -1,0 +1,99 @@
+"""Generic debate moderator prefab."""
+
+from collections.abc import Mapping
+import dataclasses
+
+from concordia.agents import entity_agent_with_logging
+from concordia.associative_memory import basic_associative_memory
+from concordia.associative_memory import formative_memories
+from concordia.components import agent as agent_components
+from concordia.language_model import language_model
+from concordia.typing import prefab as prefab_lib
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+@dataclasses.dataclass
+class Moderator(prefab_lib.Prefab):
+    """A neutral debate moderator."""
+
+    description: str = (
+        "An entity responsible for moderating a debate and judging the winner."
+    )
+    params: Mapping[str, str] = dataclasses.field(
+        default_factory=lambda: {
+            "name": "Moderator",
+            "goal": "Ensure fair and orderly discussion.",
+            "context": "",
+        }
+    )
+
+    def build(
+        self,
+        model: language_model.LanguageModel,
+        memory_bank: basic_associative_memory.AssociativeMemoryBank,
+    ) -> entity_agent_with_logging.EntityAgentWithLogging:
+        """Build the moderator agent."""
+
+        name = self.params.get("name")
+        goal = self.params.get("goal")
+        context = self.params.get("context", "")
+
+        embedder = SentenceTransformer("all-MiniLM-L6-v2")
+
+        def embed_fn(text: str) -> np.ndarray:
+            return embedder.encode(text)
+
+        memory_factory = formative_memories.FormativeMemoryFactory(
+            model=model,
+            embedder=embed_fn,
+            shared_memories=[f"Name: {name}", f"Role: {goal}", f"Context: {context}"],
+        )
+        raw_memory_bank = memory_factory._blank_memory_factory_call()
+        memory = agent_components.memory.AssociativeMemory(raw_memory_bank)
+
+        observation = agent_components.observation.LastNObservations(
+            history_length=20, pre_act_label="\nRecent discussion:"
+        )
+        observation_to_memory = agent_components.observation.ObservationToMemory()
+
+        judgment_criteria = (
+            "Assessment criteria:\n"
+            "1. Logical consistency\n"
+            "2. Factual evidence\n"
+            "3. Persuasiveness\n"
+        )
+
+        components = {
+            "observation_to_memory": observation_to_memory,
+            agent_components.observation.DEFAULT_OBSERVATION_COMPONENT_KEY: observation,
+            agent_components.memory.DEFAULT_MEMORY_COMPONENT_KEY: memory,
+            "goal": agent_components.constant.Constant(
+                state=goal, pre_act_label="\nRole:"
+            ),
+            "context": agent_components.constant.Constant(
+                state=context, pre_act_label="\nBackground:"
+            ),
+            "judgment": agent_components.constant.Constant(
+                state=judgment_criteria, pre_act_label="\nJudgment criteria:"
+            ),
+        }
+
+        component_order = [
+            "context",
+            "goal",
+            "judgment",
+            agent_components.memory.DEFAULT_MEMORY_COMPONENT_KEY,
+            agent_components.observation.DEFAULT_OBSERVATION_COMPONENT_KEY,
+        ]
+
+        act_component = agent_components.concat_act_component.ConcatActComponent(
+            model=model,
+            component_order=component_order,
+        )
+
+        return entity_agent_with_logging.EntityAgentWithLogging(
+            agent_name=name,
+            act_component=act_component,
+            context_components=components,
+        )

--- a/pysrcai/pysrcai/debate/prefabs/entity/participant.py
+++ b/pysrcai/pysrcai/debate/prefabs/entity/participant.py
@@ -1,0 +1,97 @@
+"""Generic debate participant prefab."""
+
+from collections.abc import Mapping
+import dataclasses
+
+from concordia.agents import entity_agent_with_logging
+from concordia.associative_memory import basic_associative_memory
+from concordia.associative_memory import formative_memories
+from concordia.components import agent as agent_components
+from concordia.language_model import language_model
+from concordia.typing import prefab as prefab_lib
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+@dataclasses.dataclass
+class Participant(prefab_lib.Prefab):
+    """A generic debate participant."""
+
+    description: str = (
+        "An entity representing a debate participant with a goal and context."
+    )
+    params: Mapping[str, str] = dataclasses.field(
+        default_factory=lambda: {
+            "name": "Participant",
+            "goal": "",
+            "context": "",
+            "word_limits": None,
+        }
+    )
+
+    def build(
+        self,
+        model: language_model.LanguageModel,
+        memory_bank: basic_associative_memory.AssociativeMemoryBank,
+    ) -> entity_agent_with_logging.EntityAgentWithLogging:
+        """Build the participant agent."""
+
+        name = self.params.get("name")
+        goal = self.params.get("goal", "")
+        context = self.params.get("context", "")
+        word_limits = self.params.get("word_limits")
+
+        embedder = SentenceTransformer("all-MiniLM-L6-v2")
+
+        def embed_fn(text: str) -> np.ndarray:
+            return embedder.encode(text)
+
+        memory_factory = formative_memories.FormativeMemoryFactory(
+            model=model,
+            embedder=embed_fn,
+            shared_memories=[f"Name: {name}", f"Goal: {goal}", f"Context: {context}"],
+        )
+        raw_memory_bank = memory_factory._blank_memory_factory_call()
+
+        if word_limits:
+            opening = word_limits.get("opening", {"min": 0, "max": 50})
+            raw_memory_bank.add(
+                f"Responses should be {opening['min']}-{opening['max']} words."
+            )
+
+        memory = agent_components.memory.AssociativeMemory(raw_memory_bank)
+
+        observation = agent_components.observation.LastNObservations(
+            history_length=10, pre_act_label="\nRecent discussion:"
+        )
+        observation_to_memory = agent_components.observation.ObservationToMemory()
+
+        components = {
+            "observation_to_memory": observation_to_memory,
+            agent_components.observation.DEFAULT_OBSERVATION_COMPONENT_KEY: observation,
+            agent_components.memory.DEFAULT_MEMORY_COMPONENT_KEY: memory,
+            "goal": agent_components.constant.Constant(
+                state=goal, pre_act_label="\nGoal:"
+            ),
+            "context": agent_components.constant.Constant(
+                state=context, pre_act_label="\nContext:"
+            ),
+        }
+
+        component_order = [
+            "context",
+            "goal",
+            agent_components.memory.DEFAULT_MEMORY_COMPONENT_KEY,
+            agent_components.observation.DEFAULT_OBSERVATION_COMPONENT_KEY,
+        ]
+
+        act_component = agent_components.concat_act_component.ConcatActComponent(
+            model=model,
+            component_order=component_order,
+        )
+
+        return entity_agent_with_logging.EntityAgentWithLogging(
+            agent_name=name,
+            act_component=act_component,
+            context_components=components,
+        )

--- a/pysrcai/pysrcai/debate/scenarios/two_debate.py
+++ b/pysrcai/pysrcai/debate/scenarios/two_debate.py
@@ -1,0 +1,151 @@
+"""Simple two participant debate scenario."""
+
+import datetime
+from concordia.typing import prefab as prefab_lib
+from concordia.typing import scene as scene_lib
+from concordia.typing import entity as entity_lib
+
+# Central configuration
+WORD_LIMITS = {
+    "opening": {"min": 30, "max": 60},
+    "rebuttal": {"min": 30, "max": 60},
+    "closing": {"min": 50, "max": 80},
+    "judgment": {"min": 50, "max": 80},
+}
+
+
+PARTICIPANT_A = "Alice"
+PARTICIPANT_B = "Bob"
+MODERATOR = "Moderator"
+
+PREMISE = (
+    "Two participants engage in a friendly debate on a generic topic. "
+    "A moderator ensures fair play and decides the winner."
+)
+
+
+def _limit_text(phase: str) -> str:
+    limits = WORD_LIMITS[phase]
+    return f"LIMIT: Keep your response to {limits['min']}-{limits['max']} words."
+
+
+OPENING_SCENE = scene_lib.SceneTypeSpec(
+    name="opening",
+    game_master_name="orchestrator",
+    possible_participants=[PARTICIPANT_A, PARTICIPANT_B, MODERATOR],
+    action_spec=entity_lib.free_action_spec(
+        call_to_action=f'Present your opening statement. {_limit_text("opening")}'
+    ),
+    default_premise={
+        PARTICIPANT_A: ["State your position clearly."],
+        PARTICIPANT_B: ["State your position clearly."],
+        MODERATOR: ["Introduce the debate and give each participant the floor."],
+    },
+)
+
+REBUTTAL_SCENE = scene_lib.SceneTypeSpec(
+    name="rebuttal",
+    game_master_name="orchestrator",
+    possible_participants=[PARTICIPANT_A, PARTICIPANT_B, MODERATOR],
+    action_spec=entity_lib.free_action_spec(
+        call_to_action=f'Respond to the previous statement. {_limit_text("rebuttal")}'
+    ),
+    default_premise={
+        PARTICIPANT_A: ["Respond to your opponent."],
+        PARTICIPANT_B: ["Respond to your opponent."],
+        MODERATOR: ["Guide the rebuttal phase."],
+    },
+)
+
+CLOSING_SCENE = scene_lib.SceneTypeSpec(
+    name="closing",
+    game_master_name="orchestrator",
+    possible_participants=[PARTICIPANT_A, PARTICIPANT_B, MODERATOR],
+    action_spec=entity_lib.free_action_spec(
+        call_to_action=f'Provide your closing remarks. {_limit_text("closing")}'
+    ),
+    default_premise={
+        PARTICIPANT_A: ["Summarize your stance."],
+        PARTICIPANT_B: ["Summarize your stance."],
+        MODERATOR: ["Invite closing remarks from each participant."],
+    },
+)
+
+JUDGMENT_SCENE = scene_lib.SceneTypeSpec(
+    name="judgment",
+    game_master_name="orchestrator",
+    possible_participants=[MODERATOR],
+    action_spec=entity_lib.free_action_spec(
+        call_to_action=f'Who won the debate and why? {_limit_text("judgment")}'
+    ),
+    default_premise={
+        MODERATOR: ["Declare the winner with reasoning."],
+    },
+)
+
+SCENES = [
+    scene_lib.SceneSpec(
+        scene_type=OPENING_SCENE,
+        participants=[MODERATOR, PARTICIPANT_A, PARTICIPANT_B],
+        num_rounds=3,
+        start_time=datetime.datetime(2025, 1, 1, 9, 0),
+    ),
+    scene_lib.SceneSpec(
+        scene_type=REBUTTAL_SCENE,
+        participants=[MODERATOR, PARTICIPANT_A, PARTICIPANT_B],
+        num_rounds=3,
+        start_time=datetime.datetime(2025, 1, 1, 9, 15),
+    ),
+    scene_lib.SceneSpec(
+        scene_type=CLOSING_SCENE,
+        participants=[MODERATOR, PARTICIPANT_A, PARTICIPANT_B],
+        num_rounds=3,
+        start_time=datetime.datetime(2025, 1, 1, 9, 30),
+    ),
+    scene_lib.SceneSpec(
+        scene_type=JUDGMENT_SCENE,
+        participants=[MODERATOR],
+        num_rounds=1,
+        start_time=datetime.datetime(2025, 1, 1, 9, 45),
+    ),
+]
+
+INSTANCES = [
+    prefab_lib.InstanceConfig(
+        prefab="participant",
+        role=prefab_lib.Role.ENTITY,
+        params={
+            "name": PARTICIPANT_A,
+            "goal": "Argue in favour of position A.",
+            "context": "",
+            "word_limits": WORD_LIMITS,
+        },
+    ),
+    prefab_lib.InstanceConfig(
+        prefab="participant",
+        role=prefab_lib.Role.ENTITY,
+        params={
+            "name": PARTICIPANT_B,
+            "goal": "Argue in favour of position B.",
+            "context": "",
+            "word_limits": WORD_LIMITS,
+        },
+    ),
+    prefab_lib.InstanceConfig(
+        prefab="moderator",
+        role=prefab_lib.Role.ENTITY,
+        params={
+            "name": MODERATOR,
+            "goal": "Ensure fair play and judge the debate.",
+            "context": "",
+        },
+    ),
+    prefab_lib.InstanceConfig(
+        prefab="dialogic_and_dramaturgic_gm",
+        role=prefab_lib.Role.GAME_MASTER,
+        params={
+            "name": "orchestrator",
+            "scenes": SCENES,
+        },
+    ),
+]

--- a/pysrcai/pysrcai/debate/start.py
+++ b/pysrcai/pysrcai/debate/start.py
@@ -1,0 +1,24 @@
+"""CLI entry point for running a simple debate."""
+
+from importlib import import_module
+import argparse
+
+from pysrcai.pysrcai.debate.engine.generic_debate import DebateEngine
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a debate simulation.")
+    parser.add_argument(
+        "--scenario",
+        default="pysrcai.pysrcai.debate.scenarios.two_debate",
+        help="Python module containing SCENES and INSTANCES.",
+    )
+    args = parser.parse_args()
+
+    scenario = import_module(args.scenario)
+    engine = DebateEngine(scenario)
+    engine.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add initial debate engine package
- implement participant and moderator prefabs
- create simple two participant scenario
- add CLI entrypoint and generic engine

## Testing
- `black pysrcai/pysrcai/debate/scenarios/two_debate.py`
- `pytest` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860416abedc832fa8e2d4342097494c